### PR TITLE
Add title to Washington DC svg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ class USAMap extends React.Component {
           <g className="DC state">
             <path className="DC1" fill={this.fillStateColor("DC1")} d="M801.8,253.8 l-1.1-1.6 -1-0.8 1.1-1.6 2.2,1.5z" />
             <circle className="DC2" onClick={this.clickHandler} data-name={"DC"} fill={this.fillStateColor("DC2")} stroke="#FFFFFF" strokeWidth="1.5" cx="801.3" cy="251.8" r="5" opacity="1" />
+            <title>Washington DC</title>
           </g>
         </g>
       </svg>


### PR DESCRIPTION
The Washington DC svg `<g />` did not have a `<title />`, resulting in
mouse over to display the default title "Blank US states map". This
commit adds the full name title "Washington DC".