### PR TITLE
make width and height accept `string` or `number`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,8 +52,8 @@ class USAMap extends React.Component {
 
 USAMap.propTypes = {
   onClick: PropTypes.func.isRequired,
-  width: PropTypes.number,
-  height: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   title: PropTypes.string,
   defaultFill: PropTypes.string,
   customize: PropTypes.object


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26561931/128056817-3fb0ae05-f54a-4ad7-8804-ed9aa5d7e84f.png)

Currently, `height` and `width` are have `PropTypes` that limit the values to be _only_ numbers.

But, the `<svg/>` tag doesn't have such a limitation, making valid height/width arguments like this

```js
    <USAMap
      customize={stateConfigurations}
      defaultFill="#F8F8F8"
      height={'100%'}
      width={'100%'}
    />
```

Very noisy in the console.